### PR TITLE
fix: UserInfo always responds to missing

### DIFF
--- a/lib/cognito_idp/user_info.rb
+++ b/lib/cognito_idp/user_info.rb
@@ -14,7 +14,7 @@ module CognitoIdp
     end
 
     def respond_to_missing?(method, include_private = false)
-      @attributes.key?(method)
+      true
     end
   end
 end


### PR DESCRIPTION
Fixes #1.

The internal OpenStruct doesn't respond to `key?` and always responds to
missing so the only meaningful thing to do is always respond to missing.
