### PR TITLE
fix: Use standard Base64 encoding for Basic Auth (RFC 7617)

### DIFF
--- a/lib/cognito_idp/client.rb
+++ b/lib/cognito_idp/client.rb
@@ -99,7 +99,7 @@ module CognitoIdp
       return if client_secret.nil?
 
       client_id_and_secret = "#{client_id}:#{client_secret}"
-      {"Authorization" => "Basic #{Base64.urlsafe_encode64(client_id_and_secret)}"}
+      {"Authorization" => "Basic #{Base64.strict_encode64(client_id_and_secret)}"}
     end
   end
 end

--- a/spec/cognito_idp/client_spec.rb
+++ b/spec/cognito_idp/client_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe CognitoIdp::Client do
           Faraday::Adapter::Test::Stubs.new do |stub|
             stub.post("https://auth.example.com/oauth2/token") do |env|
               id_and_secret = "#{client_id}:#{client_secret}"
-              basic_auth = "Basic #{Base64.urlsafe_encode64(id_and_secret)}"
+              basic_auth = "Basic #{Base64.strict_encode64(id_and_secret)}"
               fail "Basic Authorization is missing." unless env.request_headers["Authorization"] == basic_auth
               [200, {"Content-Type" => "application/json"}, response_payload.to_json]
             end
@@ -204,7 +204,7 @@ RSpec.describe CognitoIdp::Client do
         Faraday::Adapter::Test::Stubs.new do |stub|
           stub.post("https://auth.example.com/oauth2/token", params_matcher) do |env|
             id_and_secret = "#{client_id}:#{client_secret}"
-            basic_auth = "Basic #{Base64.urlsafe_encode64(id_and_secret)}"
+            basic_auth = "Basic #{Base64.strict_encode64(id_and_secret)}"
             fail "Basic Authorization is missing." unless env.request_headers["Authorization"] == basic_auth
             [200, {"Content-Type" => "application/json"}, response_payload.to_json]
           end
@@ -325,7 +325,7 @@ RSpec.describe CognitoIdp::Client do
           Faraday::Adapter::Test::Stubs.new do |stub|
             stub.post("https://auth.example.com/oauth2/token") do |env|
               id_and_secret = "#{client_id}:#{client_secret}"
-              basic_auth = "Basic #{Base64.urlsafe_encode64(id_and_secret)}"
+              basic_auth = "Basic #{Base64.strict_encode64(id_and_secret)}"
               fail "Basic Authorization is missing." unless env.request_headers["Authorization"] == basic_auth
               [200, {"Content-Type" => "application/json"}, response_payload.to_json]
             end
@@ -373,7 +373,7 @@ RSpec.describe CognitoIdp::Client do
         Faraday::Adapter::Test::Stubs.new do |stub|
           stub.post("https://auth.example.com/oauth2/token", params_matcher) do |env|
             id_and_secret = "#{client_id}:#{client_secret}"
-            basic_auth = "Basic #{Base64.urlsafe_encode64(id_and_secret)}"
+            basic_auth = "Basic #{Base64.strict_encode64(id_and_secret)}"
             fail "Basic Authorization is missing." unless env.request_headers["Authorization"] == basic_auth
             [200, {"Content-Type" => "application/json"}, response_payload.to_json]
           end


### PR DESCRIPTION
`urlsafe_encode64` produces URL-safe Base64 (`+` → `-`, `/` → `_`),
which is incorrect for HTTP Basic Authentication. Use `strict_encode64`
to produce standard Base64 without newlines, as required by RFC 7617.
