### PR TITLE
fix: Redact secrets and tokens from #inspect

### DIFF
--- a/lib/cognito_idp/client.rb
+++ b/lib/cognito_idp/client.rb
@@ -15,6 +15,14 @@ module CognitoIdp
       @stubs = stubs
     end
 
+    def inspect
+      "#<#{self.class}:0x#{object_id.to_s(16)} " \
+        "@adapter=#{adapter.inspect}, " \
+        "@client_id=#{client_id.inspect}, " \
+        "@client_secret=#{client_secret.nil? ? "nil" : "[REDACTED]"}, " \
+        "@domain=#{domain.inspect}>"
+    end
+
     def authorization_uri(redirect_uri:, **options)
       AuthorizationUri.new(
         client_id: client_id,

--- a/lib/cognito_idp/token.rb
+++ b/lib/cognito_idp/token.rb
@@ -14,5 +14,15 @@ module CognitoIdp
       end
       @expires_at = Time.now + expires_in unless expires_in.nil?
     end
+
+    def inspect
+      "#<#{self.class}:0x#{object_id.to_s(16)} " \
+        "@access_token=#{access_token.nil? ? "nil" : "[REDACTED]"}, " \
+        "@id_token=#{id_token.nil? ? "nil" : "[REDACTED]"}, " \
+        "@token_type=#{token_type.inspect}, " \
+        "@expires_in=#{expires_in.inspect}, " \
+        "@expires_at=#{expires_at.inspect}, " \
+        "@refresh_token=#{refresh_token.nil? ? "nil" : "[REDACTED]"}>"
+    end
   end
 end

--- a/spec/cognito_idp/client_spec.rb
+++ b/spec/cognito_idp/client_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe CognitoIdp::Client do
     expect(CognitoIdp::VERSION).not_to be nil
   end
 
+  describe "#inspect" do
+    it "redacts client_secret when set" do
+      client = described_class.new(client_id: "id", client_secret: "super-secret", domain: "auth.example.com")
+      expect(client.inspect).to include("@client_secret=[REDACTED]")
+      expect(client.inspect).not_to include("super-secret")
+    end
+
+    it "shows nil when client_secret is not set" do
+      client = described_class.new(client_id: "id", domain: "auth.example.com")
+      expect(client.inspect).to include("@client_secret=nil")
+    end
+
+    it "shows non-secret attributes" do
+      client = described_class.new(client_id: "id", domain: "auth.example.com")
+      expect(client.inspect).to include('@client_id="id"')
+      expect(client.inspect).to include('@domain="auth.example.com"')
+    end
+  end
+
   describe "#authorization_uri" do
     subject(:uri) { client.authorization_uri(redirect_uri: redirect_uri) }
 

--- a/spec/cognito_idp/token_spec.rb
+++ b/spec/cognito_idp/token_spec.rb
@@ -16,6 +16,48 @@ RSpec.describe CognitoIdp::Token do
   it { expect(token.expires_at).to be_nil }
   it { expect(token.refresh_token).to be_nil }
 
+  describe "#inspect" do
+    context "when token values are set" do
+      let(:token_hash) do
+        {
+          "access_token" => "secret-access",
+          "id_token" => "secret-id",
+          "token_type" => "Bearer",
+          "expires_in" => 3600,
+          "refresh_token" => "secret-refresh"
+        }
+      end
+
+      it "redacts access_token" do
+        expect(token.inspect).to include("@access_token=[REDACTED]")
+        expect(token.inspect).not_to include("secret-access")
+      end
+
+      it "redacts id_token" do
+        expect(token.inspect).to include("@id_token=[REDACTED]")
+        expect(token.inspect).not_to include("secret-id")
+      end
+
+      it "redacts refresh_token" do
+        expect(token.inspect).to include("@refresh_token=[REDACTED]")
+        expect(token.inspect).not_to include("secret-refresh")
+      end
+
+      it "shows non-secret attributes" do
+        expect(token.inspect).to include('@token_type="Bearer"')
+        expect(token.inspect).to include("@expires_in=3600")
+      end
+    end
+
+    context "when token values are nil" do
+      it "shows nil for absent tokens" do
+        expect(token.inspect).to include("@access_token=nil")
+        expect(token.inspect).to include("@id_token=nil")
+        expect(token.inspect).to include("@refresh_token=nil")
+      end
+    end
+  end
+
   context "when token is initialized with values" do
     let(:token_hash) do
       {


### PR DESCRIPTION
Override #inspect on Client and Token to replace sensitive values
(client_secret, access_token, id_token, refresh_token) with
[REDACTED], preventing leaks via logging or error reporting.
