### PR TITLE
fix: Tighten UserInfo and attr mutability

### DIFF
--- a/lib/cognito_idp/authorization_uri.rb
+++ b/lib/cognito_idp/authorization_uri.rb
@@ -2,7 +2,7 @@
 
 module CognitoIdp
   class AuthorizationUri
-    attr_accessor :client_id, :code_challenge_method, :code_challenge, :domain,
+    attr_reader :client_id, :code_challenge_method, :code_challenge, :domain,
       :idp_identifier, :identity_provider, :nonce, :redirect_uri, :response_type,
       :scope, :state
 

--- a/lib/cognito_idp/client.rb
+++ b/lib/cognito_idp/client.rb
@@ -5,7 +5,7 @@ require "faraday"
 
 module CognitoIdp
   class Client
-    attr_accessor :adapter, :client_id, :client_secret, :domain
+    attr_reader :adapter, :client_id, :client_secret, :domain
 
     def initialize(client_id:, domain:, client_secret: nil, adapter: Faraday.default_adapter, stubs: nil)
       @adapter = adapter

--- a/lib/cognito_idp/logout_uri.rb
+++ b/lib/cognito_idp/logout_uri.rb
@@ -2,7 +2,7 @@
 
 module CognitoIdp
   class LogoutUri
-    attr_accessor :client_id, :domain, :logout_uri, :redirect_uri, :response_type, :scope, :state
+    attr_reader :client_id, :domain, :logout_uri, :redirect_uri, :response_type, :scope, :state
 
     def initialize(client_id:, domain:, **options)
       @client_id = client_id

--- a/lib/cognito_idp/user_info.rb
+++ b/lib/cognito_idp/user_info.rb
@@ -14,7 +14,7 @@ module CognitoIdp
     end
 
     def respond_to_missing?(method, include_private = false)
-      true
+      @attributes.respond_to?(method, include_private) || super
     end
   end
 end

--- a/spec/cognito_idp/user_info_spec.rb
+++ b/spec/cognito_idp/user_info_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe CognitoIdp::UserInfo do
   it { expect(user_info.email_verified).to be_nil }
   it { expect(user_info.phone_number_verified).to be_nil }
 
+  describe "#respond_to?" do
+    context "when attribute exists" do
+      let(:user_info_hash) { {"email" => "jane@example.com"} }
+
+      it { expect(user_info).to respond_to(:email) }
+    end
+
+    context "when attribute does not exist" do
+      it { expect(user_info).not_to respond_to(:nonexistent) }
+    end
+  end
+
   context "when given attributes" do
     let(:user_info_hash) do
       {


### PR DESCRIPTION
Delegate respond_to_missing? to the underlying OpenStruct so it
only returns true for attributes that exist, rather than for any
method name. Change attr_accessor to attr_reader on Client,
AuthorizationUri, and LogoutUri to prevent mutation after init.
