### PR TITLE
chore: Bump minimum Ruby version to 2.7

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,3 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.6
+ruby_version: 2.7

--- a/cognito_idp-client.gemspec
+++ b/cognito_idp-client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Client for interacting with Amazon Cognito IdP (User Pools) endpoints."
   spec.homepage = "https://github.com/appercept/cognito_idp-ruby"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
The codebase already uses argument forwarding (...) which requires
Ruby 2.7+, and the CI matrix starts at 2.7.
