### PR TITLE
chore: Add ostruct dependency for Ruby 3.5 compat

### DIFF
--- a/cognito_idp-client.gemspec
+++ b/cognito_idp-client.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
   spec.add_dependency "faraday", "~> 2.7"
+  spec.add_dependency "ostruct"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
ostruct is being removed from Ruby's default gems in 3.5.
