### PR TITLE
fix: Correct logout_uri test calling wrong method

### DIFF
--- a/spec/cognito_idp/client_spec.rb
+++ b/spec/cognito_idp/client_spec.rb
@@ -759,7 +759,7 @@ RSpec.describe CognitoIdp::Client do
     it { expect(decoded_uri_params).to include(["client_id", client_id]) }
 
     context "when given additional valid options" do
-      subject(:uri) { client.authorization_uri(redirect_uri: redirect_uri, state: state) }
+      subject(:uri) { client.logout_uri(redirect_uri: redirect_uri, state: state) }
 
       let(:redirect_uri) { "https://www.example.com/auth/callback" }
       let(:state) { "STATE" }


### PR DESCRIPTION
The "additional valid options" context in the #logout_uri describe block
was calling client.authorization_uri instead of client.logout_uri,
meaning redirect_uri and state parameters were never tested against
the logout endpoint.
